### PR TITLE
トピック選好度の更新

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+credentials.json

--- a/server/app/route/projects/songs/music_parts/measure/music_loop/get_updated_topic_preferences.py
+++ b/server/app/route/projects/songs/music_parts/measure/music_loop/get_updated_topic_preferences.py
@@ -1,15 +1,16 @@
 import os
-import numpy as np
-from sklearn import preprocessing
-import math
-import statistics
-import librosa
 
+# import numpy as np
+# from sklearn import preprocessing
+# import math
+# import statistics
+# import librosa
 import psycopg2
 from dotenv import load_dotenv
 from psycopg2.extras import DictCursor
-import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
+
+# import matplotlib.pyplot as plt
+# from mpl_toolkits.mplot3d import Axes3D
 
 
 load_dotenv()

--- a/server/app/route/projects/songs/music_parts/measure/music_loop/music_loop.py
+++ b/server/app/route/projects/songs/music_parts/measure/music_loop/music_loop.py
@@ -59,7 +59,6 @@ def insert_sound(uid, project_id, song_id, part_id, measure, musicloop_id):
     fix = int(fix_req) if fix_req is not None else 0
     adapt_req = params.get("adapt")
     adapt = int(adapt_req) if adapt_req is not None else 0
-    print(f"fix: {fix}, adapt: {adapt}")
 
     if fix == 0:
         target_loop_id = get_chorded_loop_id(musicloop_id, measure)

--- a/server/app/route/projects/songs/music_parts/measure/music_loop/music_loop.py
+++ b/server/app/route/projects/songs/music_parts/measure/music_loop/music_loop.py
@@ -1,19 +1,21 @@
+
 from flask import Blueprint, jsonify, make_response, request
 from sqls import (
     check_song_loop_log,
-    get_parts,
-    get_song_loop_ids,
-    update_song_details,
-    update_wav_data,
     get_loop_id,
     get_loop_id_from_id_chord,
+    get_parts,
+    get_song_loop_ids,
     insert_loop_log,
+    update_song_details,
+    update_wav_data,
 )
 from util.connect_sound import connect_sound
-from util.const import fix_len, topic_n
-from util.topic import update_topic_ratio
-from verify import require_auth
+from util.const import fix_len
 from util.give_chord import get_chorded_loop_id
+from verify import require_auth
+
+from .update_topic_preferences import update_topic_preferences
 
 mesure_music_loop = Blueprint("mesure_music_loop", __name__)
 
@@ -57,6 +59,7 @@ def insert_sound(uid, project_id, song_id, part_id, measure, musicloop_id):
     fix = int(fix_req) if fix_req is not None else 0
     adapt_req = params.get("adapt")
     adapt = int(adapt_req) if adapt_req is not None else 0
+    print(f"fix: {fix}, adapt: {adapt}")
 
     if fix == 0:
         target_loop_id = get_chorded_loop_id(musicloop_id, measure)
@@ -106,8 +109,7 @@ def insert_sound(uid, project_id, song_id, part_id, measure, musicloop_id):
     sound_ids_by_measure_part = [list(arr) for arr in zip(*sound_ids_by_part_measure)]
 
     if adapt == 1:
-        update_topic_ratio(part_id, musicloop_id, uid, topic_n=topic_n)
-
+        update_topic_preferences(uid, musicloop_id)
     _, wav_data = connect_sound(
         sound_ids_by_measure_part, project_id, "insert", song_id
     )

--- a/server/app/route/projects/songs/music_parts/measure/music_loop/update_topic_preferences.py
+++ b/server/app/route/projects/songs/music_parts/measure/music_loop/update_topic_preferences.py
@@ -1,0 +1,34 @@
+from sqls import (
+    get_loop_info_topics,
+    get_topic_id_ns,
+    get_topic_preferences_from_part_excitement,
+    update_topic_preferences_from_topic_preferences,
+)
+from util.const import topic_n
+
+from .get_updated_topic_preferences import get_updated_topic_preferences
+
+
+def update_topic_preferences(user_id, loop_id):
+    updated_topic_preferences, _, part_id, excitement = get_updated_topic_preferences(user_id, loop_id)
+    topic_id_ns = get_topic_id_ns()
+    topic_n_ids = list(
+        map(lambda x: x["id"], filter(lambda x: x["number"] == topic_n, topic_id_ns))
+    )
+
+    loop_info = get_loop_info_topics(loop_id)
+    topic_preferences = get_topic_preferences_from_part_excitement(
+        user_id, part_id, excitement
+    )
+
+    topic_n_preferences = list(
+        filter(lambda x: x["topic_id"] in topic_n_ids, topic_preferences)
+    )
+    topic_n_preferences = sorted(topic_n_preferences, key=lambda x: x["topic_id"])
+
+    loop_n_info = list(filter(lambda x: x["topic_id"] in topic_n_ids, loop_info))
+    loop_n_info = sorted(loop_n_info, key=lambda x: x["topic_id"])
+
+    for topic_i in range(topic_n):
+        topic_n_preferences[topic_i]["value"] = updated_topic_preferences[topic_i]
+    update_topic_preferences_from_topic_preferences(user_id, topic_n_preferences)

--- a/server/app/sqls/loop.py
+++ b/server/app/sqls/loop.py
@@ -183,7 +183,7 @@ def get_loop_topics(loop_id: int):
 
 def get_loop_info_topics(loop_id: int):
     sql = """
-    select
+    select distinct
         loops.id,
         loops.name,
         loops.excitement,

--- a/server/app/sqls/loop.py
+++ b/server/app/sqls/loop.py
@@ -1,7 +1,7 @@
+from cache import cache
 from psycopg2.extras import DictCursor
 
 from .connection import get_connection
-from cache import cache
 
 
 @cache.memoize()
@@ -105,7 +105,7 @@ def get_loop_topic_by_id(loop_id: int):
 @cache.memoize()
 def get_loop_and_topics_from_part(part_id: int):
     sql = """
-    SELECT
+    SELECT DISTINCT
         loops.id,
         loops.name,
         loops.excitement,

--- a/server/app/sqls/topic.py
+++ b/server/app/sqls/topic.py
@@ -1,8 +1,8 @@
+from cache import cache
 from psycopg2.extras import DictCursor
 
 from .connection import get_connection
 from .part import get_parts
-from cache import cache
 
 
 @cache.memoize()
@@ -13,6 +13,8 @@ def get_topic_id_ns():
             number
         FROM
             topics
+        where
+            excitement is not null
     """
     response = None
     with get_connection() as conn:

--- a/server/app/sqls/topic.py
+++ b/server/app/sqls/topic.py
@@ -14,7 +14,7 @@ def get_topic_id_ns():
         FROM
             topics
         where
-            excitement is not null
+            excitement is null
     """
     response = None
     with get_connection() as conn:

--- a/server/app/tests/settings.py
+++ b/server/app/tests/settings.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.getcwd())
+sys.path.append(os.path.join(os.getcwd(), "app"))
+#
+import firebase_admin
+from cache import cache
+from dotenv import load_dotenv
+from firebase_admin import credentials
+from flask import Flask
+from flask_cors import CORS
+
+load_dotenv()
+
+cred = credentials.Certificate("app/credentials.json")
+firebase_app = firebase_admin.initialize_app(cred)
+
+app = Flask(__name__)
+CORS(app)
+cache.init_app(app)
+print(sys.path)

--- a/server/app/tests/test_get_topic.py
+++ b/server/app/tests/test_get_topic.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-import settings
+import settings  # noqa: F401
 from sqls import get_topic_id_ns
 
 # cred = credentials.Certificate("app/credentials.json")
@@ -15,21 +15,15 @@ class TestGetTopic(TestCase):
     def test_get_topic(self):
         print("test_get_topic")
         want_topic_id_ns = [
-            {"id": 10, "number": 3},
-            {"id": 11, "number": 3},
-            {"id": 12, "number": 3},
-            {"id": 13, "number": 3},
-            {"id": 14, "number": 3},
-            {"id": 15, "number": 3},
-            {"id": 16, "number": 3},
-            {"id": 17, "number": 3},
-            {"id": 18, "number": 3},
-            {"id": 19, "number": 3},
-            {"id": 20, "number": 3},
-            {"id": 21, "number": 3},
-            {"id": 22, "number": 3},
-            {"id": 23, "number": 3},
-            {"id": 24, "number": 3},
+            {"id": 1, "number": 2},
+            {"id": 2, "number": 2},
+            {"id": 3, "number": 3},
+            {"id": 4, "number": 3},
+            {"id": 5, "number": 3},
+            {"id": 6, "number": 4},
+            {"id": 7, "number": 4},
+            {"id": 8, "number": 4},
+            {"id": 9, "number": 4},
         ]
         got_topic_id_ns = get_topic_id_ns()
         self.assertEqual(want_topic_id_ns, got_topic_id_ns)

--- a/server/app/tests/test_get_topic.py
+++ b/server/app/tests/test_get_topic.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+
+import settings
+from sqls import get_topic_id_ns
+
+# cred = credentials.Certificate("app/credentials.json")
+# firebase_app = firebase_admin.initialize_app(cred)
+
+# app = Flask(__name__)
+# CORS(app)
+# cache.init_app(app)
+
+
+class TestGetTopic(TestCase):
+    def test_get_topic(self):
+        print("test_get_topic")
+        want_topic_id_ns = [
+            {"id": 10, "number": 3},
+            {"id": 11, "number": 3},
+            {"id": 12, "number": 3},
+            {"id": 13, "number": 3},
+            {"id": 14, "number": 3},
+            {"id": 15, "number": 3},
+            {"id": 16, "number": 3},
+            {"id": 17, "number": 3},
+            {"id": 18, "number": 3},
+            {"id": 19, "number": 3},
+            {"id": 20, "number": 3},
+            {"id": 21, "number": 3},
+            {"id": 22, "number": 3},
+            {"id": 23, "number": 3},
+            {"id": 24, "number": 3},
+        ]
+        got_topic_id_ns = get_topic_id_ns()
+        self.assertEqual(want_topic_id_ns, got_topic_id_ns)
+
+
+if __name__ == "__main__":
+    from unittest import main
+
+    main()

--- a/server/app/tests/test_make_random_sound.py
+++ b/server/app/tests/test_make_random_sound.py
@@ -1,0 +1,167 @@
+import pprint as pp
+from unittest import TestCase
+
+import settings  # noqa: F401
+from psycopg2.errors import UniqueViolation
+from route.projects.songs.choose_sound import (
+    choose_sound_randomly,
+    choose_sound_randomly_with_using_ratio_topic,
+    get_part_loop_values,
+)
+from sqls import get_parts
+from util.const import part_name2index
+
+
+def init0(topic_n_preferences_by_part_measure_topic):
+    for (
+        part,
+        topic_n_preferences_by_measure_topic,
+    ) in topic_n_preferences_by_part_measure_topic.items():
+        for (
+            measure,
+            topic_n_preferences_by_topic,
+        ) in topic_n_preferences_by_measure_topic.items():
+            for topic_id, preference in topic_n_preferences_by_topic.items():
+                # print(topic_id, preference)
+                topic_n_preferences_by_part_measure_topic[part][measure][topic_id] = 0
+
+
+def init1(topic_n_preferences_by_part_measure_topic, select_part=None):
+    for (
+        part,
+        topic_n_preferences_by_measure_topic,
+    ) in topic_n_preferences_by_part_measure_topic.items():
+        for (
+            measure,
+            topic_n_preferences_by_topic,
+        ) in topic_n_preferences_by_measure_topic.items():
+            for topic_id, preference in topic_n_preferences_by_topic.items():
+                # print(topic_id, preference)
+                topic_n_preferences_by_part_measure_topic[part][measure][topic_id] = (
+                    1 if select_part is None or part == select_part else 0
+                )
+
+
+class TestInit(TestCase):
+    def test_init0(self):
+        print("test_init0")
+        from route.projects.songs.choose_sound import get_topic_preferences_by_topic_n
+        from sqls.topic_preferences import init_topic_preferences
+        from sqls.user import add_user_by_firebase_id
+
+        firebase_id = "test"
+        try:
+            add_user_by_firebase_id(firebase_id)
+            init_topic_preferences(firebase_id)
+        except UniqueViolation:
+            pass
+
+        topic_n_preferences_by_part_measure_topic = get_topic_preferences_by_topic_n(
+            firebase_id
+        )
+        init0(topic_n_preferences_by_part_measure_topic)
+        for (
+            topic_n_preferences_by_measure_topic
+        ) in topic_n_preferences_by_part_measure_topic.values():
+            for (
+                topic_n_preferences_by_topic
+            ) in topic_n_preferences_by_measure_topic.values():
+                for preference in topic_n_preferences_by_topic.values():
+                    self.assertEqual(preference, 0)
+
+    def test_init1(self):
+        print("test_init1")
+        from route.projects.songs.choose_sound import get_topic_preferences_by_topic_n
+        from sqls.topic_preferences import init_topic_preferences
+        from sqls.user import add_user_by_firebase_id
+
+        parts = get_parts()
+
+        firebase_id = "test"
+        try:
+            add_user_by_firebase_id(firebase_id)
+            init_topic_preferences(firebase_id)
+        except UniqueViolation:
+            pass
+
+        topic_n_preferences_by_part_measure_topic = get_topic_preferences_by_topic_n(
+            firebase_id
+        )
+
+        for part in parts:
+            init1(topic_n_preferences_by_part_measure_topic, select_part=part["id"])
+            for (
+                part_id,
+                topic_n_preferences_by_measure_topic,
+            ) in topic_n_preferences_by_part_measure_topic.items():
+                for (
+                    topic_n_preferences_by_topic
+                ) in topic_n_preferences_by_measure_topic.values():
+                    for preference in topic_n_preferences_by_topic.values():
+                        self.assertEqual(preference, 1 if part_id == part["id"] else 0)
+
+        init1(topic_n_preferences_by_part_measure_topic)
+        for (
+            topic_n_preferences_by_measure_topic
+        ) in topic_n_preferences_by_part_measure_topic.values():
+            for (
+                topic_n_preferences_by_topic
+            ) in topic_n_preferences_by_measure_topic.values():
+                for preference in topic_n_preferences_by_topic.values():
+                    self.assertEqual(preference, 1)
+
+
+class TestMakeRandomSound(TestCase):
+
+    def test_get_topicpreferences(self):
+        print("test_get_topicpreferences")
+        from route.projects.songs.choose_sound import get_topic_preferences_by_topic_n
+        from sqls.topic_preferences import init_topic_preferences
+        from sqls.user import add_user_by_firebase_id
+
+        firebase_id = "test"
+        try:
+            add_user_by_firebase_id(firebase_id)
+            init_topic_preferences(firebase_id)
+        except UniqueViolation:
+            pass
+
+        topic_n_preferences_by_part_measure_topic = get_topic_preferences_by_topic_n(
+            firebase_id
+        )
+        init0(topic_n_preferences_by_part_measure_topic)
+
+        parts = get_parts()
+        parts = sorted(parts, key=lambda x: part_name2index[x["name"]])
+
+        for part in parts:
+            sound_list = choose_sound_randomly_with_using_ratio_topic(
+                part["id"],
+                topic_n_preferences_by_part_measure_topic[part["id"]],
+            )
+            self.assertEqual(sound_list, [])
+
+        for _part in parts:
+            init1(topic_n_preferences_by_part_measure_topic, select_part=_part["id"])
+            # pp.pprint(topic_n_preferences_by_part_measure_topic[_part["id"]])
+            print("get part loop values", _part["id"])
+            print(get_part_loop_values(_part["id"]))
+
+            for part in parts:
+                # print(
+                #     part["id"],
+                #     _part["id"],
+                #     topic_n_preferences_by_part_measure_topic[part["id"]],
+                # )
+                sound_list = choose_sound_randomly_with_using_ratio_topic(
+                    part["id"],
+                    topic_n_preferences_by_part_measure_topic[part["id"]],
+                )
+                # print(part, _part, sound_list)
+                # if part["id"] == _part["id"]:
+                #     self.assertNotEqual(sound_list, [])
+                # else:
+                self.assertEqual(sound_list, [])
+
+        sound_list = choose_sound_randomly(firebase_id)
+        print(sound_list)


### PR DESCRIPTION
- 作ってもらったやつを使ってトピック選好度を更新
- トピックIDの被りは応急的に，SQLで重複を消して対処
- 一部ユニットテストの作成