### PR TITLE
#43: Googleのガイドラインに沿ったログイン画面に修正

### DIFF
--- a/client/src/components/Auth.jsx
+++ b/client/src/components/Auth.jsx
@@ -26,19 +26,16 @@ export function UserProvider({ children }) {
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
 }
 
-export function signIn() {
+export async function signIn() {
   const googleProvider = new GoogleAuthProvider();
   googleProvider.setCustomParameters({
     prompt: "select_account",
   });
 
-  firebaseSignIn(auth, googleProvider)
-    .then((result) => {
-      console.log(result);
-    })
-    .catch((error) => {
-      console.log(error);
-    });
+  const result = await firebaseSignIn(auth, googleProvider).catch(
+    (error) => error,
+  );
+  console.log(result);
 }
 
 export function signOut() {

--- a/client/src/components/signIn/GoogleLoginButton.jsx
+++ b/client/src/components/signIn/GoogleLoginButton.jsx
@@ -1,0 +1,48 @@
+import styles from "./googleLogin.module.css";
+
+export default function GoogleLoginButton({ disable }) {
+  const {
+    "gsi-material-button": gsiButton,
+    "gsi-material-button-state": gsiButtonState,
+    "gsi-material-button-content-wrapper": gsiButtonContentWrapper,
+    "gsi-material-button-icon": gsiButtonIcon,
+    " gsi-material-button-contents": gsiButtonContents,
+  } = styles;
+
+  return (
+    <button type="submit" disabled={disable} className={gsiButton}>
+      <div className={gsiButtonState} />
+      <div className={gsiButtonContentWrapper}>
+        <div className={gsiButtonIcon}>
+          <svg
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 48 48"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            style={{ display: "block" }}
+          >
+            <path
+              fill="#EA4335"
+              d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            />
+            <path
+              fill="#4285F4"
+              d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            />
+            <path
+              fill="#34A853"
+              d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            />
+            <path fill="none" d="M0 0h48v48H0z" />
+          </svg>
+        </div>
+        <span className={gsiButtonContents}>Sign in with Google</span>
+        <span style={{ display: "none" }}>Sign in with Google</span>
+      </div>
+    </button>
+  );
+}

--- a/client/src/components/signIn/SignIn.jsx
+++ b/client/src/components/signIn/SignIn.jsx
@@ -25,7 +25,7 @@ function SignInUI({ handleSignIn, isError, isLoading }) {
     <Container>
       <Stack spacing={8}>
         <Box textAlign="center" marginTop={8}>
-          <Heading size="sm">ランサーIDを入力してログイン</Heading>
+          <Heading size="sm">IDを入力してログイン</Heading>
         </Box>
         <Box>
           <FormControl isInvalid={isError}>
@@ -42,12 +42,12 @@ function SignInUI({ handleSignIn, isError, isLoading }) {
               <Stack spacing={12}>
                 <Stack spacing={2}>
                   <FormControl isRequired isDisabled={isLoading}>
-                    <FormLabel>ランサーID</FormLabel>
+                    <FormLabel>ID</FormLabel>
                     <Input type="text" name="id" />
                   </FormControl>
                   <FormControl isInvalid={isError}>
                     <Checkbox name="register" isDisabled={isLoading}>
-                      ランサーIDを登録する
+                      IDを登録する
                     </Checkbox>
                     <FormHelperText>
                       以前にIDを登録したことがある場合は上書きされます
@@ -120,13 +120,16 @@ export default function SignIn() {
 
   return (
     <SignInUI
-      handleSignIn={(inputUserOwnId, userWantRegister) => {
+      handleSignIn={async (inputUserOwnId, userWantRegister) => {
         setUserOwnId(inputUserOwnId);
         setWantRegister(userWantRegister);
         flushSync(() => {
           setIsLoading(true);
         });
-        firebaseSignIn();
+        await firebaseSignIn();
+        flushSync(() => {
+          setIsLoading(false);
+        });
       }}
       isError={isError.current}
       isLoading={isLoading}

--- a/client/src/components/signIn/SignIn.jsx
+++ b/client/src/components/signIn/SignIn.jsx
@@ -1,6 +1,6 @@
 import {
   Box,
-  Button,
+  Center,
   Checkbox,
   Container,
   FormControl,
@@ -16,6 +16,8 @@ import { flushSync } from "react-dom";
 import { useNavigate } from "react-router-dom";
 
 import { signIn as firebaseSignIn, signOut, useUser } from "../Auth";
+
+import GoogleLoginButton from "./GoogleLoginButton";
 
 import checkSignIn from "@/api/authentication/checkSignIn";
 import registerUser from "@/api/authentication/registerUser";
@@ -58,9 +60,9 @@ function SignInUI({ handleSignIn, isError, isLoading }) {
                   </FormControl>
                 </Stack>
 
-                <Button type="submit" isLoading={isLoading}>
-                  Sign in with Google
-                </Button>
+                <Center>
+                  <GoogleLoginButton disable={isLoading} />
+                </Center>
               </Stack>
             </form>
 

--- a/client/src/components/signIn/googleLogin.module.css
+++ b/client/src/components/signIn/googleLogin.module.css
@@ -1,0 +1,113 @@
+.gsi-material-button {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-appearance: none;
+  background-color: WHITE;
+  background-image: none;
+  border: 1px solid #747775;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #1f1f1f;
+  cursor: pointer;
+  font-family: "Roboto", arial, sans-serif;
+  font-size: 14px;
+  height: 40px;
+  letter-spacing: 0.25px;
+  outline: none;
+  overflow: hidden;
+  padding: 0 12px;
+  position: relative;
+  text-align: center;
+  -webkit-transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  max-width: 400px;
+  min-width: min-content;
+}
+
+.gsi-material-button .gsi-material-button-icon {
+  height: 20px;
+  margin-right: 12px;
+  min-width: 20px;
+  width: 20px;
+}
+
+.gsi-material-button .gsi-material-button-content-wrapper {
+  -webkit-align-items: center;
+  align-items: center;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  height: 100%;
+  justify-content: space-between;
+  position: relative;
+  width: 100%;
+}
+
+.gsi-material-button .gsi-material-button-contents {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  font-family: "Roboto", arial, sans-serif;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+}
+
+.gsi-material-button .gsi-material-button-state {
+  -webkit-transition: opacity 0.218s;
+  transition: opacity 0.218s;
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.gsi-material-button:disabled {
+  cursor: default;
+  background-color: #ffffff61;
+  border-color: #1f1f1f1f;
+}
+
+.gsi-material-button:disabled .gsi-material-button-contents {
+  opacity: 38%;
+}
+
+.gsi-material-button:disabled .gsi-material-button-icon {
+  opacity: 38%;
+}
+
+.gsi-material-button:not(:disabled):active .gsi-material-button-state,
+.gsi-material-button:not(:disabled):focus .gsi-material-button-state {
+  background-color: #303030;
+  opacity: 12%;
+}
+
+.gsi-material-button:not(:disabled):hover {
+  -webkit-box-shadow:
+    0 1px 2px 0 rgba(60, 64, 67, 0.3),
+    0 1px 3px 1px rgba(60, 64, 67, 0.15);
+  box-shadow:
+    0 1px 2px 0 rgba(60, 64, 67, 0.3),
+    0 1px 3px 1px rgba(60, 64, 67, 0.15);
+}
+
+.gsi-material-button:not(:disabled):hover .gsi-material-button-state {
+  background-color: #303030;
+  opacity: 8%;
+}


### PR DESCRIPTION
# 修正内容
ガイドライン：https://developers.google.com/identity/branding-guidelines?hl=ja
- ランサーIDを入力する、という文言を修正
- ボタンのアイコンをGoogleのガイドラインに沿ったものに修正
- サインインをキャンセルしたときにログインができなくなる問題の修正
  - やや時間がかかるがボタンが戻る

# 外観
![image](https://github.com/user-attachments/assets/481ff439-11df-4c30-98fe-49728e84fdc2)

ログイン途中でボタンを押せないようにしている。
ここからアカウントの選択画面を閉じたら、再度ボタンが押せるようになる
![image](https://github.com/user-attachments/assets/60ec62dd-52e7-4df6-9864-3b779ec027a2)
